### PR TITLE
fix (gitignore): retire les types graphql générés

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ dist-ssr
 .idea
 .env
 persist/
+frontend/src/generated/graphql-types.ts


### PR DESCRIPTION
place dans gitignore le fichier contenant les types graphql autogénérés