### PR TITLE
feat: PR de Flamanville

### DIFF
--- a/backend/src/resolvers/CityResolver.ts
+++ b/backend/src/resolvers/CityResolver.ts
@@ -11,7 +11,7 @@ import {
 } from "type-graphql";
 
 import { 
-	IsNumber, 
+	IsNumber,
 	IsString, 
 	Max, 
 	MaxLength, 
@@ -56,9 +56,15 @@ class CreateCityInput {
 	// createdBy: User;
 }
 
-// Lors de la modification de la ville, on NE doit PAS modifier l'utilisateur créateur de la ville
+// Modification de la ville
 @InputType()
 class UpdateCityInput {
+
+	@Field()
+	@IsString({message: "Le nom de la ville doit être un texte"})
+	@MinLength(2, {message: "Le nom de la ville doit compter au moins 2 caractères"})
+	cityName: string;
+
 	@Field()
 	@IsString({ message: "La description de la ville doit être un texte." })
 	@MinLength(10, { message: "La descritpion de la ville doit compter au moins 10 caractères." })
@@ -67,6 +73,18 @@ class UpdateCityInput {
 	@Field()
 	@IsString()
 	imageUrl: string;
+
+	@Field()
+	@IsNumber()
+	@Min(-90, { message: "La latitude doit être supérieure à -90." })
+	@Max(90, { message: "La longitude doit être inférieure à 90." })
+	cityLatitude!: number;
+
+	@Field()
+	@IsNumber()
+	@Min(-180, { message: "La latitude doit être supérieure à -180." })
+	@Max(180, { message: "La longitude doit être inférieure à 180." })
+	cityLongitude!: number;
 }
 
 @Resolver(City)
@@ -104,7 +122,7 @@ export default class CityResolver {
 
 	// Modifier une ville
 	@Authorized("ADMIN_SITE", "ADMIN_CITY")
-	@Mutation(() => ID)
+	@Mutation(() => City)
 	async updateCity(@Arg("cityId") cityId: number, @Arg("data") data: UpdateCityInput) {
 
 			// Récupérer la ville à partir de l'id fourni
@@ -115,7 +133,7 @@ export default class CityResolver {
 
 			// Sauvegarder les modifications
 			await city.save();
-			return city.cityId;
+			return city;
 	}
 
 	// Supprimer une ville

--- a/frontend/src/components/BackofficeCity.tsx
+++ b/frontend/src/components/BackofficeCity.tsx
@@ -1,9 +1,11 @@
 import { MapContainer, TileLayer, Marker, Popup, useMap } from 'react-leaflet';
 import L from 'leaflet';
-import React, { use, useEffect, useState, type FormEvent } from "react"
+import React, { useState, type FormEvent } from "react"
 import useImageVerificationAndUpload from '../pages/backofficeHandler/imageVerificationAndUpload';
 import { useCityStore } from '../zustand/cityStore';
-import { useCreateCityMutation, useGetAllCitiesQuery, useUpdateOneCityMutation, type City, type CreateCityMutationOptions, type NewUserInput, type UpdateCityInput } from '../generated/graphql-types';
+import { useCreateCityMutation, useGetAllCitiesQuery, useGetOneCityQuery, useUpdateOneCityMutation, type City, type CreateCityMutationOptions, type NewUserInput, type UpdateCityInput } from '../generated/graphql-types';
+import City from '../pages/City';
+import { GET_ALL_CITIES } from '../graphql/operations';
 
 export default function BackofficeCity() {
 
@@ -70,9 +72,8 @@ export default function BackofficeCity() {
 		}
 	}
 
-
 	// IMAGES ! 
-	const { resetUseState, imageUploadUseState, validateImageFrontEndSide, validateUrl } = useImageVerificationAndUpload() // import de fonctions de vérifications de l'images
+	const { resetUseState, imageUploadUseState, validateImageFrontEndSide, validateUrl } = useImageVerificationAndUpload() // import de fonctions de vérifications de l'image
 	const { isImageValid, displayImage, imgSrc, imageError } = imageUploadUseState(); 
 
 	// vérification de l'image côté front-end
@@ -82,173 +83,140 @@ export default function BackofficeCity() {
 		// on réinitialise les states
 		resetUseState(); 
 
-		// L'utilisateur a décidé de choisir d'uploader une photo: on efface donc le lien de l'input url
-		const imageUrlLink = document.getElementById('imageUrl-link') as HTMLInputElement;
-		if (imageUrlLink) {
-			imageUrlLink.value = ''
-			console.log("URL effacée")
-		}
-
 		if (!file) {
 			throw new Error('Erreur lors du chargement du fichier')
 		}
 		validateImageFrontEndSide(file)
-
 	}
 
-	// l'utilisateur a choisit d'envoyer un lien au lieu d'uploader une image
-	const validateCityImageUrl = (url: string) => {
+	// TODO requête trop lourde (toutes les villes au lieu d'une seule pour les modif)
 
-		// on réinitialise les states
-		resetUseState()
-
-		// on efface le fichier, si un fichier a été fournie avant le lien
-		const fileInput = document.getElementById('imageUrl-file') as HTMLInputElement;
-		if (fileInput) {
-			fileInput.value = '';
-		}
-		if(!fileInput) {
-			const editFileInput = document.getElementById('image-update-file') as HTMLInputElement; 
-			editFileInput.value = ""
-		}
-
-		validateUrl(url)
-	}
-
+	// CRÉATION D'UNE VILLE
 	const handleAddCitySubmit = async (e: FormEvent<HTMLFormElement>) => {
 		e.preventDefault();
-    const form = e.currentTarget;
-    const formAddCityData = new FormData(form);
-    
-    try {
-        // Map form data to the correct structure
-        const cityInput = {
-            cityName: formAddCityData.get('cityName') as string,
-            description: formAddCityData.get('description') as string,
-            imageUrl: imgSrc, // Use the validated image URL from state
-            cityLatitude: Number(formAddCityData.get('cityLatitude')),
-            cityLongitude: Number(formAddCityData.get('cityLongitude'))
-        };
+		const form = e.currentTarget;
+		const formAddCityData = new FormData(form);
 
-        const { data } = await createCity({
-            variables: {
-                data: cityInput
-            }
-        });
+		try {
+			// Map form data to the correct structure KÉCÉCÉKECECOMMENTAIREMOISI ????
+			const cityInput = {
+				cityName: formAddCityData.get('cityName') as string,
+				description: formAddCityData.get('description') as string,
+				imageUrl: imgSrc, // Use the validated image URL from state
+				cityLatitude: Number(formAddCityData.get('cityLatitude')),
+				cityLongitude: Number(formAddCityData.get('cityLongitude'))
+			};
 
-        if (!data) throw new Error('Missing data');
-        
-        alert('Ville créée avec succès !');
-        form.reset();
-        resetUseState();
-        setShowMap(false);
-        
-    } catch (error) {
-        console.error('Erreur lors de la création de la ville:', error);
-        alert('Erreur lors de la création de la ville');
-    }
-	}
+			const { data } = await createCity({
+				variables: {
+						data: cityInput
+				},
+				refetchQueries: [
+					{ query: GET_ALL_CITIES }
+				]
+			});
 
-	const [editCity, setEditCity] = useState(false);
-	const [editCityId, setEditCityId] = useState(0);
-	const [editCityName, setEditCityName] = useState('');
-	const [editCityDescription, setEditCityDescription] = useState('')
-	const [editImageUrl, setEditImageUrl] = useState('');
-	const [editCityLatitude, setEditCityLatitude] = useState(0);
-	const [editCityLongitude, setEditCityLongitude] = useState(0);
-	const [newCityLatitude, setNewCityLatitude] = useState(0);
-	const [newCityLongitude, setNewCityLongitude] = useState(0)
-	const editCityHandler = (id: string) => {
-		const city = allCitiesData?.getAllCities.find(city => city.cityId === Number(id));
-		if (!city) {
-			console.log("error finding the city")
-			return
-		};
-		setEditCityId(city.cityId)
-		setEditCityName(city.cityName);
-		setEditCityDescription(city.description);
-		setEditImageUrl(city.imageUrl);
-		setEditCityLatitude(city.cityLatitude);
-		setEditCityLongitude(city.cityLongitude);
-		setNewCityLatitude(city.cityLatitude);
-		setNewCityLongitude(city.cityLongitude);
+			if (!data) throw new Error('Missing data');
+			
+			alert('Ville créée avec succès !');
+			form.reset();
+			resetUseState();
+			setShowMap(false);
 
-		if (editCityName === '') setEditCity(false)
-		setEditCity(true)
-	}
-
-	// LA DESCRIPTION
-	// Permet lors du changement de ville à éditer depuis le select, d'obtenir le texte de la description correspondant à la ville choisie
-	const [descriptionUpdate, setDescriptionUpdate] = useState(editCityDescription);
-
-	// Au changement dans le select, on récupère la bonne description
-	useEffect(() => {
-		setDescriptionUpdate(editCityDescription);
-	}, [editCityDescription]);
-
-	// Set des compteurs de caractères
-	const [charCountCreate, setCharCountCreate] = useState(0);
-	const [charCountUpdate, setCharCountUpdate] = useState(editCityDescription.length);
-
-	// Quand la description change, on récupère la nouvelle description + on compte le nombre de caractères saisis
-	const handleDescriptionUpdateChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-		setDescriptionUpdate(e.target.value);
-		setCharCountUpdate(e.target.value.length);
-	};
-
-	// Compte des caractères de la description pour une création de ville
-	const handleCharCountCreate = (value: string) => {
-		setCharCountCreate(value.length);
-	};
-
-	// RàZ du compteur de caractères de la description de ville lors de sa création lorsqu'on arrive sur l'onglet création de ville
-	useEffect(() => {
-		if (adminTabCities === 'createCity') {
-			setCharCountCreate(0); // remet le compteur à zéro
+		} catch (error) {
+			console.error('Erreur lors de la création de la ville:', error);
+			alert('Erreur lors de la création de la ville');
 		}
-	}, [adminTabCities]);
-
-	// Set le compteur de caractères de la description d'une ville pour sa modification au nombre de caractères de la description actuelle
-	useEffect(() => {
-		setCharCountUpdate(editCityDescription.length);
-	}, [editCityDescription.length]);
-
-	// LATITUDE / LONGITUDE ET VUE SUR LA MAP
-	const setNewCityLongitudeHandler = (value: number) => {
-		setNewCityLongitude(value)
-		console.log("this is the value of setNewCityLongitudeHandler : ", value)
 	}
 
-	const setNewCityLatitudeHandler = (value: number) => {
-		setNewCityLatitude(value)
+	// MODIFICATION D'UNE VILLE
+	// UseState de la ville à modifier
+	const [cityToUpdate, setCityToUpdate] = useState<null | City>(null);
+	const [currentLatitude, setCurrentLatitude] = useState(0);
+	const [currentLongitude, setCurrentLongitude] = useState(0);
+
+	// Fonction appelée lors du choix d'une ville dans le select
+	const editCityHandler = (id: string) => {
+
+		// Récupération de la vile à modifier
+		const city = allCitiesData?.getAllCities.find(city => city.cityId === Number(id));
+		if (!city) return;
+
+		// Stockage de la latitude et de la longitude pré-modification
+		setCurrentLatitude(city.cityLatitude);
+		setCurrentLongitude(city.cityLongitude);
+
+		// Set de la city à modifier
+		setCityToUpdate(city);
+
+		// Si la ville à modifier n'existe pas / n'est pas trouvée, arrêt du traitement
+		if (!cityToUpdate) {
+			return;
+		}
 	}
 
+	// GESTION DES CHANGEMENTS
+	// Nom
+	const handleCityNameUpdate = (e: React.ChangeEvent<HTMLInputElement>) => {
+		if (!cityToUpdate) return;
+		setCityToUpdate({...cityToUpdate, cityName: e.target.value});
+	};
+
+	// Description
+		const handleCityDescriptionUpdate = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+		if (!cityToUpdate) return;
+		setCityToUpdate({...cityToUpdate, description: e.target.value});
+	};
+
+	// Image : traitée par la même fonction que pour la création de ville (validateCityImage)
+
+	// Coordonnées
+	const handleCityLatitudeUpdate = (e: React.ChangeEvent<HTMLInputElement>) => {
+		if (!cityToUpdate) return;
+		setCityToUpdate({...cityToUpdate, cityLatitude: Number(e.target.value)});
+	};
+	const handleCityLongitudeUpdate = (e: React.ChangeEvent<HTMLInputElement>) => {
+		if (!cityToUpdate) return;
+		setCityToUpdate({...cityToUpdate, cityLongitude: Number(e.target.value)});
+	};
+
+	// CENTRAGE DE LA CARTE SUR LES COORDONNÉES GPS FOURNIES
 	function ChangeMapView({ center, zoom }: { center: [number, number], zoom: number }) {
 		const map = useMap();
 		map.setView(center, zoom);
 		return null;
 	}
 
+	// ENREGISTREMENT DES NOUVELLES DONNÉES DE LA VILLE
 	const updateCityHandler = async (e: FormEvent<HTMLFormElement>) => {
 		e.preventDefault();
-		// const form = e.currentTarget;
-		// const formData = new FormData(form);
 
 		try {
 
 			const updateCityInput=  { 
-				cityName : editCityName as string, 
-				description: editCityDescription as string, 
-				imageUrl: editImageUrl,
-				cityLatitude : editCityLatitude,
-				cityLongitude: editCityLongitude
+				cityName : cityToUpdate?.cityName as string, 
+				description: cityToUpdate?.description as string, 
+				imageUrl: imgSrc as string || cityToUpdate?.imageUrl as string,
+				cityLatitude : cityToUpdate?.cityLatitude as number,
+				cityLongitude: cityToUpdate?.cityLongitude as number
 			}
-			const { data } = await updateCity({
-				variables:
-					{ data: updateCityInput, cityId: editCityId }
 
+			const { data } = await updateCity({
+				variables: { 
+						data: updateCityInput, 
+						cityId: cityToUpdate?.cityId as number 
+				},
+				refetchQueries: [
+					{ query: GET_ALL_CITIES }
+				],
+				awaitRefetchQueries: true
 			})
-			if (!data) throw new Error("Missing data");
+
+			if (!data) {
+				throw new Error("Missing data")
+			} else {
+				alert("Ville modifiée avec succès ! ")
+			};
 
 		} catch (error) {
 			console.error(error)
@@ -262,20 +230,23 @@ export default function BackofficeCity() {
 				<div className={"tab__btn " + (adminTabCities === 'createCity' ? 'active' : '')} onClick={() => handleAdminTabCities('createCity')}>
 					<h3>Ajouter une ville</h3>
 				</div>
-				<div className={"tab__btn " + (adminTabCities === 'admin-city' ? 'active' : '')} onClick={() => handleAdminTabCities('admin-city')}>
+				<div className={"tab__btn " + (adminTabCities === 'updateCity' ? 'active' : '')} onClick={() => handleAdminTabCities('updateCity')}>
 					<h3>Administrer une ville</h3>
 				</div>
 			</div>
 
 			<div className="backoffice-container">
+
 				{/* ajouter une ville */}
 				{adminTabCities === "createCity" &&
 					<form onSubmit={handleAddCitySubmit}>
 
+						{/* Nom de la ville */}
 						<label htmlFor="cityName">Nom de la ville
 							<input type="text" name="cityName" placeholder="Lyon" required />
 						</label>
 
+						{/* Description */}
 						<label htmlFor="description">Description
 							<textarea
 								name="description" 
@@ -283,16 +254,20 @@ export default function BackofficeCity() {
 								className='description-field' 
 								minLength={ 10 } 
 								maxLength={ 80 } 
-								onChange={(e) => handleCharCountCreate(e.target.value)} 
 							/>
-							<p>{ charCountCreate } / 80</p>
 						</label>
 
+						{/* Image */}
 						<label htmlFor="imageUrl" className='vertical' >Image
 							<div>
-								<input type="file" name="imageUrl" id="imageUrl-file" placeholder="Image" accept="image/jpeg, image/png, image/jpg, image/webp" onChange={validateCityImage} />
-								<span>or</span>
-								<input type="url" name='imageUrl' id="imageUrl-link" placeholder="https://my-image.com" onBlur={(e) => validateCityImageUrl(e.target.value)} />
+								<input
+									type="file" 
+									name="imageUrl" 
+									id="imageUrl-file" 
+									placeholder="Image" 
+									accept="image/jpeg, image/png, image/jpg, image/webp" 
+									onChange={ validateCityImage }
+								/>
 							</div>
 							{isImageValid === 'false' &&
 								<div className="img-div"><span className="img-div__error">{imageError}</span></div>
@@ -320,22 +295,41 @@ export default function BackofficeCity() {
 							{displayImage === true &&
 								<img src={imgSrc} style={{ maxHeight: "300px" }} />}
 						</label>
+
+						{/* Coordonnées */}
 						<p>Coordonnées</p>
 						<div className="add-ville-coordonnees">
 							<label htmlFor="cityLatitude">Latitude
-								<input type="number" name="cityLatitude" min="-90" max="90" placeholder="-48.876667" onBlur={(e) => checkCoordinateInput(e, setIsLatitudeValid, 'latitude')} required />
+								<input
+									type="number"
+									name="cityLatitude"
+									min="-90" max="90"
+									step="0.000001"
+									placeholder="-48.876667"
+									onBlur={(e) => checkCoordinateInput(e, setIsLatitudeValid, 'latitude')}
+									required
+								/>
 								{isLatitudeValid === false && <p>{coordinateFormatError}</p>}
 							</label>
 							<label htmlFor="cityLongitude">Longitude
-								<input type="number" name="cityLongitude" min="-180" max="180" placeholder="-123.393333" onChange={(e) => checkCoordinateInput(e, setIsLongitudeValid, 'longitude')} required />
+								<input
+									type="number"
+									name="cityLongitude"
+									min="-180"
+									max="180"
+									step="0.000001"
+									placeholder="-123.393333"
+									onChange={(e) => checkCoordinateInput(e, setIsLongitudeValid, 'longitude')}
+									required
+								/>
 								{isLongitudeValid === false && <p>{coordinateFormatError}</p>}
 							</label>
 						</div>
 						{showMap &&
 							<MapContainer
-								center={[mapLatitude, mapLongitude]} // Paris
+								center={[mapLatitude, mapLongitude]}
 								zoom={13}
-								style={{ height: '300px', width: '100%' }}
+								style={{ height: '300px', width: '70%', alignSelf: 'center'}}
 							>
 								<TileLayer
 									url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
@@ -348,81 +342,165 @@ export default function BackofficeCity() {
 								</Marker>
 							</MapContainer>
 						}
+
+						{/* Bouton de validation de la création de ville */}
 						<input type="submit" value="Ajouter la ville"/>
 					</form>}
 
 				{/* administrer une ville */}
-				{adminTabCities === "admin-city" &&
+				{adminTabCities === "updateCity" &&
 					<div className="backoffice-container">
+
+						{/* Choix de la ville à éditer */}
 						<label htmlFor="select-ville">Choisissez une ville à éditer
 							<select name="select-ville" onChange={(e) => editCityHandler(e.target.value)}>
+								<option value="">Sélectionnez une ville</option>
 								{allCitiesData?.getAllCities.map((city) => (
-									<option value={city.cityId} key={city.cityId} defaultValue=''>{city.cityName}</option>
+									<option value={city.cityId} key={city.cityId}>{city.cityName}</option>
 								))}
 							</select>
 						</label>
-						{editCity === true &&
+
+						{/* Si la ville est trouvée, affichage du formulaire pré-rempli de modification de la ville */}
+						{ cityToUpdate?.cityId &&
 							<div className='backoffice-container relative'>
-								<h4>Editer la ville : {editCityName}</h4>
+
+								{/* Croix de fermeture du formulaire d'update de ville (haut droite) */}
 								<div className="close" onClick={() => { setEditCity(false); setEditCityName('') }}>
 									<svg height={15} width={15}>
 										<line x1="2" y1="2" x2="10" y2="10" style={{ stroke: "red", strokeWidth: 1 }} />
-										<line x1="
-									2" y1="10" x2="10" y2="2" style={{ stroke: "red", strokeWidth: 1 }} />
+										<line x1="2" y1="10" x2="10" y2="2" style={{ stroke: "red", strokeWidth: 1 }} />
 									</svg>
 								</div>
+
 								<form onSubmit={updateCityHandler}>
+
+									{/* Nom de la ville */}
 									<label htmlFor='cityName'>Nom de la ville :
-										<input type="text" defaultValue={editCityName} name='cityName' />
+										<input 
+										type="text"
+										value={cityToUpdate?.cityName}
+										name='cityName'
+										onChange={ handleCityNameUpdate }
+									/>
 									</label>
-									<label htmlFor='description'>Description de la ville
+
+									{/* Description*/}
+									<label htmlFor='description'>Description de la ville :
 										<textarea 
 											className='description-field' 
-											value={descriptionUpdate}
+											value={cityToUpdate.description}
 											name="description" 
 											minLength={ 10 } 
 											maxLength={ 80 } 
-											// onChange={ (e) => { handleCharCountUpdate(e.target.value) }}
-											onChange={handleDescriptionUpdateChange}
+											onChange={ handleCityDescriptionUpdate }
 										/>
-										<p>{ charCountUpdate } / 80</p>
 									</label>
-									<label htmlFor='imageUrl' className='vertical'>Image de la ville
-										{editImageUrl !== '' && <img src={editImageUrl} height="300px" width="500px" />}
-										<span>URL de l'image actuelle : {editImageUrl}</span>
-										<input type="file" name="imageUrl" placeholder="Image" id="image-update-file" accept="image/jpeg, image/png, image/jpg, image/webp" onChange={validateCityImage} />
-										<span>ou</span>
-										<input type="url" name="imageUrl" onBlur={(e) => validateCityImageUrl(e.target.value)} />
+
+									{/* Image */}
+									<label 
+										htmlFor='imageUrl'
+										className='vertical'
+									>Image actuelle :
+										{cityToUpdate.imageUrl !== '' && <img src={cityToUpdate.imageUrl} height="300px" width="500px" />}
+										<div>
+											<input 
+												type="file"
+												name="imageUrl"
+												placeholder="Image"
+												id="image-update-file"
+												accept="image/jpeg, image/png, image/jpg, image/webp"
+
+												// Vérification du fichier fourni
+												onChange={ validateCityImage }
+											/>
+										</div>
+										{isImageValid === 'false' &&
+											<div className="img-div"><span className="img-div__error">{imageError}</span></div>
+										}
+										{isImageValid === 'true' &&
+											<div className="img-div">
+												<svg
+													xmlns="http://www.w3.org/2000/svg"
+													width="24"
+													height="24"
+													viewBox="0 0 24 24"
+												>
+													<path
+														d="M5 13 L9 17 L19 7"
+														fill="none"
+														stroke="#22c55e"
+														strokeWidth="2.5"
+														strokeLinecap="round"
+														strokeLinejoin="round"
+													/>
+												</svg>
+												<p>Nouvelle image :</p>
+												<span className="img-div__valid">Image valide</span>
+											</div>}
+										{displayImage === true &&
+											<img src={imgSrc} style={{ maxHeight: "300px" }} />}
 									</label>
+
+									{/* Coordonnées */}
 									<h5>Coordonnées</h5>
-									<label htmlFor='cityLatitude'>Latitude
-										<span>Ancienne valeure : {editCityLatitude}</span>
-										<input type="number" defaultValue={editCityLatitude} name="cityLatitude" onChange={(e) => { setNewCityLatitudeHandler(Number(e.target.value)) }} />
-									</label>
-									<label htmlFor='cityLongitude'>Longitude
-										<span>Ancienne valeure : {editCityLongitude}</span>
-										<input type="number" defaultValue={editCityLongitude} name="cityLongitude" onChange={(e) => { setNewCityLongitudeHandler(Number(e.target.value)) }} />
-									</label>
+									<div className='latitude-longitude'>
+										<p>Latitude actuelle : { currentLatitude }</p>
+										<label htmlFor='cityLatitude'>
+											Nouvelle latitude : 
+											<input
+												type="number" 
+												value={cityToUpdate.cityLatitude} 
+												name="cityLatitude"
+												min="-90" 
+												max="90"
+												step="0.000001"
+												onChange={ handleCityLatitudeUpdate }
+											/>
+										</label>
+									</div>
+									
+									<div className='latitude-longitude'>
+										<p>Longitude actuelle : { currentLongitude }</p>
+										<label htmlFor='cityLongitude'>
+											Nouvelle longitude : 
+											<input
+												type="number"
+												value={cityToUpdate.cityLongitude}
+												name="cityLongitude"
+												min="-180"
+												max="180"
+												step="0.000001"
+												onChange={ handleCityLongitudeUpdate }
+											/>
+										</label>
+									</div>
+
+									{/* Map */}
 									<MapContainer
-										center={[newCityLatitude, newCityLongitude]}
+										center={[cityToUpdate.cityLatitude, cityToUpdate.cityLongitude]}
 										zoom={13}
-										style={{ height: '300px', width: '100%' }}
+										style={{ height: '300px', width: '70%', alignSelf: 'center' }}
+										className='map-update-city'
 									>
-										<ChangeMapView center={[newCityLatitude, newCityLongitude]} zoom={13} />
+										<ChangeMapView center={[cityToUpdate.cityLatitude, cityToUpdate.cityLongitude]} zoom={13} />
+
 										<TileLayer
 											url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
 											attribution="&copy; OpenStreetMap contributors"
 										/>
-										<Marker position={[newCityLatitude, newCityLongitude]}>
-										</Marker>
+
+										<Marker position={[cityToUpdate.cityLatitude, cityToUpdate.cityLongitude]}></Marker>
 									</MapContainer>
+
+									{/* bouton de validation du form */}
 									<input type="submit" value="Modifier la ville" />
 								</form>
 							</div>
 						}
-					</div>}
+				</div>
+			}
 			</div>
-
 		</>
 	)
 }

--- a/frontend/src/generated/graphql-types.ts
+++ b/frontend/src/generated/graphql-types.ts
@@ -65,7 +65,7 @@ export type Mutation = {
   logout: UserResponse;
   signup: UserResponse;
   updateCategory: Scalars['ID']['output'];
-  updateCity: Scalars['ID']['output'];
+  updateCity: City;
   updatePoi: Scalars['ID']['output'];
   updateUserData: Scalars['ID']['output'];
   updateUserInfo: Scalars['ID']['output'];
@@ -253,6 +253,9 @@ export enum Role {
 }
 
 export type UpdateCityInput = {
+  cityLatitude: Scalars['Float']['input'];
+  cityLongitude: Scalars['Float']['input'];
+  cityName: Scalars['String']['input'];
   description: Scalars['String']['input'];
   imageUrl: Scalars['String']['input'];
 };
@@ -338,7 +341,7 @@ export type UpdateOneCityMutationVariables = Exact<{
 }>;
 
 
-export type UpdateOneCityMutation = { __typename?: 'Mutation', updateCity: string };
+export type UpdateOneCityMutation = { __typename?: 'Mutation', updateCity: { __typename?: 'City', cityId: number } };
 
 export type GetAllPoisQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -616,7 +619,9 @@ export type GetOneCitySuspenseQueryHookResult = ReturnType<typeof useGetOneCityS
 export type GetOneCityQueryResult = Apollo.QueryResult<GetOneCityQuery, GetOneCityQueryVariables>;
 export const UpdateOneCityDocument = gql`
     mutation UpdateOneCity($data: UpdateCityInput!, $cityId: Float!) {
-  updateCity(data: $data, cityId: $cityId)
+  updateCity(data: $data, cityId: $cityId) {
+    cityId
+  }
 }
     `;
 export type UpdateOneCityMutationFn = Apollo.MutationFunction<UpdateOneCityMutation, UpdateOneCityMutationVariables>;

--- a/frontend/src/graphql/operations.ts
+++ b/frontend/src/graphql/operations.ts
@@ -71,8 +71,10 @@ export const GET_ONE_CITY = gql`
 `;
 
 export const UPDATE_ONE_CITY = gql`
-	mutation UpdateOneCity($data: UpdateCityInput!, $cityId: Float!) {		
-		updateCity(data: $data, cityId: $cityId)
+	mutation UpdateOneCity($data: UpdateCityInput!, $cityId: Float!) {
+		updateCity(data: $data, cityId: $cityId) {
+			cityId
+		}
 }
 `
 

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -10,67 +10,69 @@ import SearchBar from "../components/SearchBar.tsx";
 // GraphQL
 import {useGetAllCitiesQuery} from "../generated/graphql-types";
 import type {CityType} from "./City.tsx";
+import City from "./City.tsx";
 
 export default function HomePage() {
-    const {data, loading, error} = useGetAllCitiesQuery();
-    const navigate = useNavigate();
+		const {data, loading, error} = useGetAllCitiesQuery();
+		const navigate = useNavigate();
 
-    const windowSize = window.innerWidth;
+		const windowSize = window.innerWidth;
 
-    useEffect(() => {
-        const target = sessionStorage.getItem("scrollTo");
+		const citiesCards = data?.getAllCities ?? [];
 
-        if (target) {
-            sessionStorage.removeItem("scrollTo");
-            const el = document.getElementById(target);
+		useEffect(() => {
+			const target = sessionStorage.getItem("scrollTo");
 
-            if (el) {
-                setTimeout(() => {
-                    el.scrollIntoView({behavior: "smooth"});
-                }, 0);
-            }
-        }
-    }, []);
+			if (target) {
+					sessionStorage.removeItem("scrollTo");
+					const el = document.getElementById(target);
 
-    if (loading) return <p>Loading...</p>;
-    if (error) return <p>Error :(</p>;
+					if (el) {
+							setTimeout(() => {
+									el.scrollIntoView({behavior: "smooth"});
+							}, 0);
+					}
+			}
+		}, []);
 
-    const citiesCards = data?.getAllCities ?? [];
+		const handleSelectCity = (city: CityType) => {
+				navigate(`/city/${city.cityId}`);
+		};
 
-    const handleSelectCity = (city: CityType) => {
-        navigate(`/city/${city.cityId}`);
-    };
+		if (loading) return <p>Loading...</p>;
+		if (error) return <p>Error :(</p>;
 
-    return (
-        <>
-            <h2 className="heroBanner">Découvrez les points d'intérêts de votre ville</h2>
-            <section id="cities">
-                {windowSize < 768 ? (
-                    <section className="cities-mobile">
-                        <SearchBar
-                            cities={citiesCards}
-                            onSelectCity={handleSelectCity}
-                            errorMessage={"Aucune ville trouvée"}
-                        />
-                        {citiesCards.map((currCity) => (
-                            <CityCard key={currCity.cityId} city={currCity}/>
-                        ))}
-                    </section>
 
-                ) : windowSize > 1441 ? (
-                    <Carousel visibleCount={5}>
-                        {citiesCards.map((currCity) => (
-                            <CityCard key={currCity.cityId} city={currCity}/>
-                        ))}
-                    </Carousel>
-                ) : (
-                    <Carousel visibleCount={4}>
-                        {citiesCards.map((currCity) => (
-                            <CityCard key={currCity.cityId} city={currCity}/>
-                        ))}
-                    </Carousel>
-                )}
-            </section>
-        </>
-    )
+		return (
+				<>
+						<h2 className="heroBanner">Découvrez les points d'intérêts de votre ville</h2>
+						<section id="cities">
+								{windowSize < 768 ? (
+										<section className="cities-mobile">
+												<SearchBar
+														cities={citiesCards}
+														onSelectCity={handleSelectCity}
+														errorMessage={"Aucune ville trouvée"}
+												/>
+												{citiesCards.map((currCity) => (
+														<CityCard key={currCity.cityId} city={currCity}/>
+												))}
+										</section>
+
+								) : windowSize > 1441 ? (
+										<Carousel visibleCount={5}>
+												{citiesCards.map((currCity) => (
+														<CityCard key={currCity.cityId} city={currCity}/>
+												))}
+										</Carousel>
+								) : (
+										<Carousel visibleCount={4}>
+												{citiesCards.map((currCity) => (
+														<CityCard key={currCity.cityId} city={currCity}/>
+												))}
+										</Carousel>
+								)}
+						</section>
+				</>
+		)
 }

--- a/frontend/src/scss/pages/backoffice.scss
+++ b/frontend/src/scss/pages/backoffice.scss
@@ -359,3 +359,8 @@
 	flex-direction: column;
 	align-items: start !important;
 }
+
+.latitude-longitude {
+	display: flex;
+	flex-direction: row;
+}


### PR DESCRIPTION
* Modifie le retour de la mutation updateCity dans le resolver, retourne la ville au lieu de l'id seul
* Modifie l'operation UpdateOneCity dans operation.ts : indique la propriété à retourner (l'id de la ville modifiée)
* Mise à jour de graphql-types suite à la modification de la mutation dans le resolver
* Refactore HomePage.tsx : change l'ordre des fonctions
* Permet le refetch des villes à la création d'une ville
* Retire le champ de saisie de l'URL d'image (le seul moyen de modifier l'image d'une ville est l'upload d'un fichier)
* Fait fonctionner l'update de ville
* Permet la mise à jour des villes sans refresh manuel
* Ajoute une pop-up qui confirme la réussite de la modification d'une ville
* Modifie légèrement le SCSS / style : largeur des maps, affichage de l'ancienne photo et de la nouvelle photo fournie